### PR TITLE
Create a new full chain cert when parts of the chain change

### DIFF
--- a/tasks/deploy-provided.yml
+++ b/tasks/deploy-provided.yml
@@ -16,10 +16,34 @@
     - src_path: "{{ TLS_CACHAIN_SRC_FILE }}"
       dest_path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
 
+# These series of tasks deserve an explanation.
+#
+# In the task: 'Full certificate chain created', we must concatenate several
+# files. However we should only concatenate the files when any of the input
+# files have changed. At this time, ansible does not have a mechanism for
+# this. Here we manually check the timestamps of the dependencies and the
+# output and if the dependencies are newer, then we recreate the output file.
+# a la make.
+
+- command: stat -c "%Y" "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
+  register: key_timestamp
+  changed_when: False
+- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
+  register: crt_timestamp
+  changed_when: False
+- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
+  register: cachain_timestamp
+  changed_when: False
+- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+  register: fullchain_timestamp
+  ignore_errors: yes # Intentionally fail, if the file doesn't exist
+  changed_when: False
+
 - name: Full certificate chain created
   shell: >
     cat {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
     {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt >>
     {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt
-  args:
-    creates: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+  when: fullchain_timestamp|failed or (key_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
+                                   or (crt_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
+                                   or (cachain_timestamp.stdout|int() > fullchain_timestamp.stdout|int())


### PR DESCRIPTION
Problem:
When users were re-running clank, they were experiencing certificate mismatch
errors, because our ansible was not recreating the full chain. It wasn't
recreating it because the module performing the concatenation only
checked if the full chain file previously existed not whether it should be
recreated.

Solution:
Take a stroke from make, when ever the timestamps of the inputs are newer than
the output, regenerate the output.

I tested this with the new cert changes. I also tested with debug statements to verify the `stat` timestamps were as expected.