### PR TITLE
Satisfy new requirements for Chrome to accept a self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,20 @@ If using this role to create and deploy a self-signed certificate then `openssl`
 Role Variables
 --------------
 
-| Variable                | Required | Default             | Choices     | Comments                                   |
-|-------------------------|----------|---------------------|-------------|--------------------------------------------|
-| TLS_PRIVKEY_SRC_FILE    | no       |                     |             | Path to private key on deployer system     |
-| TLS_CERT_SRC_FILE       | no       |                     |             | Path to certificate on deployer system     |
-| TLS_CACHAIN_SRC_FILE    | no       |                     |             | Path to CA chain on deployer system        |
-| TLS_DEST_BASENAME       | no       | provided cert CN*   |             | Base filename of installed certificate     |
-| TLS_CREATE_SELFSIGNED   | no       | false               | true, false | Explicitly creates self-signed certificate |
-| TLS_CERT_DEST_DIR       | no       | (distro-specific)   |             | Directory for certificates on target host  |
-| TLS_PRIVKEY_DEST_DIR    | no       | (distro-specific)   |             | Directory for private keys on target host  |
+| Variable                            | Required         | Default                     | Choices             | Comments                                                   |
+|-------------------------------------|------------------|-----------------------------|---------------------|------------------------------------------------------------|
+| TLS_PRIVKEY_SRC_FILE                | no               |                             |                     | Path to private key on deployer system                     |
+| TLS_CERT_SRC_FILE                   | no               |                             |                     | Path to certificate on deployer system                     |
+| TLS_CACHAIN_SRC_FILE                | no               |                             |                     | Path to CA chain on deployer system                        |
+| TLS_DEST_BASENAME                   | no               | provided cert CN*           |                     | Base filename of installed certificate                     |
+| TLS_CREATE_SELFSIGNED               | no               | false                       | true, false         | Explicitly creates self-signed certificate                 |
+| TLS_CERT_DEST_DIR                   | no               | (distro-specific)           |                     | Directory for certificates on target host                  |
+| TLS_PRIVKEY_DEST_DIR                | no               | (distro-specific)           |                     | Directory for private keys on target host                  |
+| TLS_SUBJECT_ALTERNATE_NAME          | no               | ansible_fqdn                |                     | The fully qualified domain behind the generated certficate |
 
 If you specify at least a TLS_PRIVKEY_SRC_FILE, TLS_CERT_SRC_FILE, and TLS_CACHAIN_SRC_FILE, then the provided files will be installed to the target. (Ansible will look in "files" directory relative to playbook if you specify a bare filename or relative path.) If these variables are not set by the deployer, then the role will create a self-signed certificate instead, with files selfsigned.crt and selfsigned.key. You can explicitly set `TLS_CREATE_SELFSIGNED: true` to override the default behavior and force creation of a self-signed certificate.
+
+**`TLS_SUBJECT_ALTERNATE_NAME`** is the Subject Alternate Name (SAN) for the generated certificate. This field indicates the host behind the certificate. A valid example would be 'local.atmo.cloud'. The Chrome browser recently made this field mandatory. If you would like to learn about the history read this SO [answer](http://stackoverflow.com/a/14648100/1213041).
 
 `*` If the deployer provides a certificate, then the certificate's indicated CN (domain) will be used as the base name of the files on the target (e.g. `example.com.key`, `example.com.crt`, `example.com.cachain.crt`, and `example.com.fullchain.crt` for example.com). If this role creates a self-signed certificate, the files will be named with "selfsigned" as the base name. In either case, setting `TLS_DEST_BASENAME` overrides this filename.
 

--- a/tasks/deploy-selfsigned.yml
+++ b/tasks/deploy-selfsigned.yml
@@ -1,4 +1,13 @@
 ---
+- name: Create a directory to store temporary files
+  file:
+    path: "{{ role_path }}/build"
+    state: directory
+
+- name: Generate ssl configuration file
+  template:
+    src: "{{ role_path }}/templates/openssl-req.cnf.j2"
+    dest: "{{ role_path }}/build/openssl-req.cnf"
 
 - name: TLS_DEST_BASENAME set to "selfsigned" if not already overridden
   set_fact:
@@ -8,12 +17,12 @@
 - name: Self-signed certificate and private key created
   tags: [selfsigned-cert-created]
   command: >
-    openssl req -new
+    openssl req
+    -config "{{ role_path }}/build/openssl-req.cnf"
+    -newkey rsa:2048
     -x509
     -nodes
-    -extensions v3_ca
     -days 3650
-    -subj "/"
     -keyout {{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key
     -out {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
   args:

--- a/templates/openssl-req.cnf.j2
+++ b/templates/openssl-req.cnf.j2
@@ -1,0 +1,27 @@
+RANDFILE = $ENV::HOME/.rnd
+
+[ req ]
+prompt = no
+distinguished_name = server_distinguished_name
+x509_extensions    = server_req_extensions
+string_mask        = utf8only
+
+[ server_distinguished_name ]
+C            = 'US'
+ST           = 'Arizona')
+L            = 'Tucson')
+O            = 'Organization Name')
+OU           = 'Organization Division')
+CN           = {{ TLS_SUBJECT_ALTERNATE_NAME | default(ansible_fqdn) }}
+emailAddress = 'test@example.com'
+
+[ server_req_extensions ]
+authorityKeyIdentifier = keyid,issuer
+subjectKeyIdentifier   = hash
+basicConstraints       = CA:FALSE
+keyUsage               = digitalSignature, keyEncipherment
+subjectAltName         = @alternate_names
+nsComment              = "OpenSSL Generated Certificate"
+
+[ alternate_names ]
+DNS.1 = {{ TLS_SUBJECT_ALTERNATE_NAME | default(ansible_fqdn) }}


### PR DESCRIPTION
Problem: Chrome 58 has greater TLS restrictions that reject certs generated from this role
Solution: Provide a SAN field (see below) and increase the private key length

### Chrome's Missing SAN field Error
![screen shot 2017-05-19 at 11 38 06 am](https://cloud.githubusercontent.com/assets/3847314/26269905/8d61ef9a-3cac-11e7-834a-ab61dcfcb1f9.png)
See https://github.com/webpack/webpack-dev-server/issues/854

### Chrome's Weak Key Error
![screen shot 2017-05-19 at 11 48 01 am](https://cloud.githubusercontent.com/assets/3847314/26269965/eeb5e378-3cac-11e7-801d-93aed72e4fab.png)
Now we create a key with 2048 bits