### PR TITLE
Let's Encrypt support and other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
     version: 16.04
   - distribution: ubuntu
     version: 14.04
-  - distribution: ubuntu
-    version: 12.04
+#  - distribution: ubuntu
+#    version: 12.04
 
 before_install:
   - 'sudo docker run -it --name=test_dummy --privileged --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:rw cyverse/ansible-test:latest-${distribution}-${version} bash'

--- a/README.md
+++ b/README.md
@@ -1,82 +1,99 @@
-TLS Certificate
-=========
+# TLS Certificate
 
-Installs TLS (SSL) certificates to the target, in one of two ways depending on configuration:
+Installs TLS (SSL) certificates to the target, in one of three ways depending on configuration:
 - Installs your provided TLS certificate, private key, and CA certificate bundle to target system.
 - Deploys a new self-signed certificate + key to target system.
+- Obtains a TLS certificate from [Let's Encrypt](https://letsencrypt.org/) and configures automated certificate renewal via cron
 
 In either case, automatically creates a "full chain" file (containing certificate + CA bundle, suitable for use with Nginx) as well.
 
-Supports Ubuntu 12+ and CentOS 5+, adding support for other distros would be easy.
-
-Caveats / notices:
-On CentOS, file permissions for the private key are set to owner root and mode 600, because the enclosing `/etc/pki/tls/private` is permissively visible. (Compare to Ubuntu where the system-wide `/etc/ssl/private` directory already has restricted permissions.) Beyond that, this role does not do anything with file permissions, like configuring additional users/groups which can read the private key. That is left for the deployer to handle in a playbook. This role also does not configure other services that use the installed certificates.
+Supports Ubuntu LTS 14+ and CentOS 6+, adding support for other distros would be easy.
 
 [![Build Status](https://travis-ci.org/CyVerse-Ansible/ansible-tls-cert.svg?branch=master)](https://travis-ci.org/CyVerse-Ansible/ansible-tls-cert)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-tls--cert-blue.svg)](https://galaxy.ansible.com/CyVerse-Ansible/tls-cert/)
 
+## Role Variables
 
-Requirements
-------------
+How to configure? Minimally:
+- If you want to deploy a provided certificate, define the `TLS_*_SRC_FILE` vars. (Ansible will look in "files" directory relative to playbook if you specify a bare filename or relative path.)
+- If you want to create+deploy a self-signed certificate, don't define any of `TLS_*_SRC_FILE`, and optionally, set `TLS_CREATE_SELFSIGNED: true`.
+- If you want to use Let's Encrypt, set `TLS_LETSENCRYPT: true` and define `TLS_LETSENCRYPT_EMAIL`, consider also defining `TLS_LETSENCRYPT_TLS_SERVICE`
+- If not deploying a provided certificate, consider also setting `TLS_COMMON_NAME`
 
-If using this role to deploy a provided certificate then `openssl` must be available on the deployment host.
-If using this role to create and deploy a self-signed certificate then `openssl` must be available on the target host.
-(These are likely already true for any modern Linux system.)
+| Variable                      | Required                     | Default             | Choices     | Comments                                                                    |
+|-------------------------------|------------------------------|---------------------|-------------|-----------------------------------------------------------------------------|
+| TLS_PRIVKEY_SRC_FILE          | no                           |                     |             | Path to private key on deployer system                                      |
+| TLS_CERT_SRC_FILE             | no                           |                     |             | Path to certificate on deployer system                                      |
+| TLS_CACHAIN_SRC_FILE          | no                           |                     |             | Path to CA chain on deployer system                                         |
+| TLS_COMMON_NAME               | no                           | ansible_fqdn        |             | The fully qualified domain for the certficate generated or obtained from LE |
+| TLS_CREATE_SELFSIGNED         | no                           | false               | true, false | Explicitly creates self-signed certificate                                  |
+| TLS_DEST_BASENAME             | no                           | provided cert CN*   |             | Base filename of installed certificate (ignored when using LE)              |
+| TLS_CERT_DEST_DIR             | no                           | (distro-specific**) |             | Directory for certificates on target host (ignored when using LE)           |
+| TLS_PRIVKEY_DEST_DIR          | no                           | (distro-specific**) |             | Directory for private keys on target host (ignored when using LE)           |
+| TLS_LETSENCRYPT               | no                           | false               | true, false | Obtain a certificate using Let's Encrypt                                    |
+| TLS_LETSENCRYPT_TLS_SERVICE   | no                           |                     |             | Name of service to stop when obtaining certificate and restart upon renewal |
+| TLS_LETSENCRYPT_EMAIL         | when TLS_LETSENCRYPT is true |                     |             | Email address to associate with Let's Encrypt certificate                   |
 
-Role Variables
---------------
+These variables are registered by this role for use in your downstream automations:
 
-| Variable                            | Required         | Default                     | Choices             | Comments                                                   |
-|-------------------------------------|------------------|-----------------------------|---------------------|------------------------------------------------------------|
-| TLS_PRIVKEY_SRC_FILE                | no               |                             |                     | Path to private key on deployer system                     |
-| TLS_CERT_SRC_FILE                   | no               |                             |                     | Path to certificate on deployer system                     |
-| TLS_CACHAIN_SRC_FILE                | no               |                             |                     | Path to CA chain on deployer system                        |
-| TLS_DEST_BASENAME                   | no               | provided cert CN*           |                     | Base filename of installed certificate                     |
-| TLS_CREATE_SELFSIGNED               | no               | false                       | true, false         | Explicitly creates self-signed certificate                 |
-| TLS_CERT_DEST_DIR                   | no               | (distro-specific)           |                     | Directory for certificates on target host                  |
-| TLS_PRIVKEY_DEST_DIR                | no               | (distro-specific)           |                     | Directory for private keys on target host                  |
-| TLS_SUBJECT_ALTERNATE_NAME          | no               | ansible_fqdn                |                     | The fully qualified domain behind the generated certficate |
+| Variable           | Comments                      |
+|--------------------|-------------------------------|
+| TLS_PRIVKEY_PATH   | Path to private key on target |
+| TLS_CERT_PATH      | Path to certificate on target |
+| TLS_CACHAIN_PATH   | Path to CA chain on target    |
+| TLS_FULLCHAIN_PATH | Path to fullchain on target   |
 
-If you specify at least a TLS_PRIVKEY_SRC_FILE, TLS_CERT_SRC_FILE, and TLS_CACHAIN_SRC_FILE, then the provided files will be installed to the target. (Ansible will look in "files" directory relative to playbook if you specify a bare filename or relative path.) If these variables are not set by the deployer, then the role will create a self-signed certificate instead, with files selfsigned.crt and selfsigned.key. You can explicitly set `TLS_CREATE_SELFSIGNED: true` to override the default behavior and force creation of a self-signed certificate.
-
-**`TLS_SUBJECT_ALTERNATE_NAME`** is the Subject Alternate Name (SAN) for the generated certificate. This field indicates the host behind the certificate. A valid example would be 'local.atmo.cloud'. The Chrome browser recently made this field mandatory. If you would like to learn about the history read this SO [answer](http://stackoverflow.com/a/14648100/1213041).
+**`TLS_COMMON_NAME`** is the Common Name (CN) for the generated certificate, and will also be used to set the Subject Alternate Name (SAN), which indicates the host behind the certificate. A valid example would be 'local.atmo.cloud'. The Chrome browser recently made this field mandatory. If you would like to learn about the history read this SO [answer](http://stackoverflow.com/a/14648100/1213041).
 
 `*` If the deployer provides a certificate, then the certificate's indicated CN (domain) will be used as the base name of the files on the target (e.g. `example.com.key`, `example.com.crt`, `example.com.cachain.crt`, and `example.com.fullchain.crt` for example.com). If this role creates a self-signed certificate, the files will be named with "selfsigned" as the base name. In either case, setting `TLS_DEST_BASENAME` overrides this filename.
 
 `**` By default, certificates and private keys are placed in the distro-specific system-wide default directories (but this can be overridden).
 
-Dependencies
-------------
+## Caveats / Notices
+- `openssl` must be available on the _deployment host_ if using this role to deploy a provided certificate, and on the _target host_ if creating+deploying a self-signed certificate. These are likely already true for any modern Linux system.
+
+- On CentOS, file permissions for the private key are set to owner root and mode 600, because the enclosing `/etc/pki/tls/private` is permissively visible. (Compare to Ubuntu where the system-wide `/etc/ssl/private` directory already has restricted permissions.) Beyond that, this role does not do anything with file permissions, like configuring additional users/groups which can read the private key. That is left for the deployer to handle in a playbook. This role also does not configure other services that use the installed certificates.
+
+- When deploying a certificate with Let's Encrypt, certbot will run in standalone mode. Port 443 must be made available for the standalone server to respond to the ACME challenge. You can provide the name of your service listening on port 443 with `TLS_LETSENCRYPT_TLS_SERVICE`, and this service will be temporarily stopped when obtaining/renewing the certificate.
+
+## Dependencies
 
 None
 
-Example Playbook
-----------------
+## Example Playbook
 
 If you already have a certificate to install:
 
     - hosts: all
       roles:
-         - tls-cert
+        - tls-cert
       vars:
-         - TLS_PRIVKEY_SRC_FILE: example.com.key
-         - TLS_CERT_SRC_FILE: example.com.crt
-         - TLS_CACHAIN_SRC_FILE: example.com.cachain.crt
+        - TLS_PRIVKEY_SRC_FILE: 'example.com.key'
+        - TLS_CERT_SRC_FILE: 'example.com.crt'
+        - TLS_CACHAIN_SRC_FILE: 'example.com.cachain.crt'
 
 If you want to create a self-signed certificate, just call the role with no variables:
 
     - hosts: all
       roles:
-         - tls-cert
+        - tls-cert
 
-License
--------
+If you want to use Let's Encrypt (example Nginx web server):
+
+    - hosts: all
+      roles:
+        - tls-cert
+      vars:
+        - TLS_LETSENCRYPT: 'true'
+        - TLS_LETSENCRYPT_HTTPS_SERVICE: 'nginx'
+        - TLS_LETSENCRYPT_EMAIL: 'dont@spam.me'
+
+## License
 
 See license.md
 
-Author Information
-------------------
-
+## Author Information
 Chris Martin
+Connor Osborn
 
 https://cyverse.org

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports Ubuntu LTS 14+ and CentOS 6+, adding support for other distros would be
 
 How to configure? Minimally:
 - If you want to deploy a provided certificate, define the `TLS_*_SRC_FILE` vars. (Ansible will look in "files" directory relative to playbook if you specify a bare filename or relative path.)
-- If you want to create+deploy a self-signed certificate, don't define any of `TLS_*_SRC_FILE`, and optionally, set `TLS_CREATE_SELFSIGNED: true`.
+- If you want to create+deploy a self-signed certificate, don't define any of `TLS_*_SRC_FILE`
 - If you want to use Let's Encrypt, set `TLS_LETSENCRYPT: true` and define `TLS_LETSENCRYPT_EMAIL`, consider also defining `TLS_LETSENCRYPT_TLS_SERVICE`
 - If not deploying a provided certificate, consider also setting `TLS_COMMON_NAME`
 
@@ -26,7 +26,6 @@ How to configure? Minimally:
 | TLS_CERT_SRC_FILE             | no                           |                     |             | Path to certificate on deployer system                                      |
 | TLS_CACHAIN_SRC_FILE          | no                           |                     |             | Path to CA chain on deployer system                                         |
 | TLS_COMMON_NAME               | no                           | ansible_fqdn        |             | The fully qualified domain for the certficate generated or obtained from LE |
-| TLS_CREATE_SELFSIGNED         | no                           | false               | true, false | Explicitly creates self-signed certificate                                  |
 | TLS_DEST_BASENAME             | no                           | provided cert CN*   |             | Base filename of installed certificate (ignored when using LE)              |
 | TLS_CERT_DEST_DIR             | no                           | (distro-specific**) |             | Directory for certificates on target host (ignored when using LE)           |
 | TLS_PRIVKEY_DEST_DIR          | no                           | (distro-specific**) |             | Directory for private keys on target host (ignored when using LE)           |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 TLS_CREATE_SELFSIGNED: false
 TLS_COMMON_NAME: '{{ ansible_fqdn }}'
 certbot_executable: 'certbot'
+le_obtain_cert: 'false'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 
 TLS_CREATE_SELFSIGNED: false
+TLS_COMMON_NAME: '{{ ansible_fqdn }}'
+certbot_executable: 'certbot'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,8 +29,8 @@ galaxy_info:
   platforms:
   - name: EL
     versions:
-    - all
-    - 5
+    #- all
+    #- 5
     - 6
     - 7
   #- name: GenericUNIX
@@ -134,14 +134,14 @@ galaxy_info:
   #  - maverick
   #  - natty
   #  - oneiric
-    - precise
-    - quantal
-    - raring
-    - saucy
+    #- precise
+    #- quantal
+    #- raring
+    #- saucy
     - trusty
-    - utopic
-    - vivid
-    - wily
+    #- utopic
+    #- vivid
+    #- wily
     - xenial
   #- name: SLES
   #  versions:

--- a/tasks/deploy-letsencrypt.yml
+++ b/tasks/deploy-letsencrypt.yml
@@ -63,21 +63,21 @@
 
 - name: Test if cert already exists
   set_fact:
-    obtain_cert: true
-  when: 'cert_stat.exists'
+    le_obtain_cert: true
+  when: 'cert_stat.stat.islnk is not defined'
 
 - name: TLS-using service stopped prior to obtaining certificate
   service:
     name: '{{ TLS_LETSENCRYPT_TLS_SERVICE }}'
     state: 'stopped'
-  when: 'obtain_cert and TLS_LETSENCRYPT_TLS_SERVICE is defined'
+  when: 'le_obtain_cert == true and TLS_LETSENCRYPT_TLS_SERVICE is defined'
 
 - name: Ensure nothing is listening on port 443
   wait_for:
     port: '443'
     state: 'stopped'
     timeout: '10'
-  when: 'obtain_cert'
+  when: 'le_obtain_cert == true'
 
 - name: Certificate obtained
   command: >-
@@ -88,17 +88,17 @@
     --agree-tos
     --email {{ TLS_LETSENCRYPT_EMAIL }}
     --domain {{ TLS_COMMON_NAME }}
-  when: 'obtain_cert'
+  when: 'le_obtain_cert == true'
 
 - name: TLS-using service started after obtaining certificate
   service:
     name: '{{ TLS_LETSENCRYPT_TLS_SERVICE }}'
     state: 'started'
-  when: 'obtain_cert and TLS_LETSENCRYPT_TLS_SERVICE is defined'
+  when: 'le_obtain_cert == true and TLS_LETSENCRYPT_TLS_SERVICE is defined'
 
 - name: Renewal command set
   set_fact:
-    renewal_command: >
+    renewal_command: >-
       {{ certbot_executable }} renew
       --pre-hook "service {{ TLS_LETSENCRYPT_TLS_SERVICE }} stop"
       --post-hook "service {{ TLS_LETSENCRYPT_TLS_SERVICE }} start"
@@ -107,18 +107,24 @@
 
 - name: Renewal command set
   set_fact:
-    renewal_command: >
+    renewal_command: >-
       {{ certbot_executable }} renew
       -n
   when: 'TLS_LETSENCRYPT_TLS_SERVICE is not defined'
+  tags:
+    - 'cron'
 
 - name: Renewal ran once
   command: '{{ renewal_command }}'
+  changed_when: false
 
 - name: Renewal automated via cron
   cron:
+    user: root
     hour: '*/12'
-    minute: '{{ 59 | random(seed=inventory_hostname) }}'
+    minute: '{{ 59 |random(seed=inventory_hostname) }}'
     job: '{{ renewal_command }} --quiet'
     name: 'certbot-renew'
-    stae: 'present'
+    state: 'present'
+  tags:
+    - 'cron'

--- a/tasks/deploy-letsencrypt.yml
+++ b/tasks/deploy-letsencrypt.yml
@@ -1,0 +1,124 @@
+---
+
+- name: File paths registered
+  set_fact:
+    TLS_PRIVKEY_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/privkey.pem'
+    TLS_CERT_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/cert.pem'
+    TLS_CACHAIN_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/chain.pem'
+    TLS_FULLCHAIN_PATH: '/etc/letsencrypt/live/{{ TLS_COMMON_NAME }}/fullchain.pem'
+
+- name: certbot installed on CentOS 6
+  get_url:
+    url: 'https://dl.eff.org/certbot-auto'
+    dest: '/opt/certbot-auto'
+    mode: 'a+x'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"'
+
+- name: certbot executable set for CentOS 6
+  set_fact:
+    certbot_executable: '/opt/certbot-auto'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"'
+
+- name: EPEL enabled for CentOS 7
+  yum:
+    name: 'epel-release'
+    state: 'installed'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"'
+
+# Todo enable EPEL optional channel?
+
+- name: certbot installed for CentOS 7
+  yum:
+    name: 'certbot'
+    state: 'installed'
+  when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"'
+
+- name: PPA dependency installed for Ubuntu
+  apt:
+    name: 'software-properties-common'
+    state: 'installed'
+  when: 'ansible_distribution == "Ubuntu"'
+
+- name: PPA dependency added for Ubuntu
+  apt_repository:
+    repo: 'ppa:certbot/certbot'
+    update_cache: true
+  when: 'ansible_distribution == "Ubuntu"'
+
+- name: certbot installed on Ubuntu
+  apt:
+    name: 'certbot'
+    state: 'latest'
+  when: 'ansible_distribution == "Ubuntu"'
+
+# To avoid hitting https://letsencrypt.org/docs/rate-limits
+# - Check to see if valid certificate already exists for requested domain
+# - Don't run certbot if a valid certificate already exists
+
+- name: Test if cert already exists
+  stat:
+    path: '{{ TLS_CERT_PATH }}'
+    follow: 'yes'
+  register: 'cert_stat'
+
+- name: Test if cert already exists
+  set_fact:
+    obtain_cert: true
+  when: 'cert_stat.exists'
+
+- name: TLS-using service stopped prior to obtaining certificate
+  service:
+    name: '{{ TLS_LETSENCRYPT_TLS_SERVICE }}'
+    state: 'stopped'
+  when: 'obtain_cert and TLS_LETSENCRYPT_TLS_SERVICE is defined'
+
+- name: Ensure nothing is listening on port 443
+  wait_for:
+    port: '443'
+    state: 'stopped'
+    timeout: '10'
+  when: 'obtain_cert'
+
+- name: Certificate obtained
+  command: >-
+    {{ certbot_executable }} certonly
+    --standalone
+    --keep-until-expiring
+    -n
+    --agree-tos
+    --email {{ TLS_LETSENCRYPT_EMAIL }}
+    --domain {{ TLS_COMMON_NAME }}
+  when: 'obtain_cert'
+
+- name: TLS-using service started after obtaining certificate
+  service:
+    name: '{{ TLS_LETSENCRYPT_TLS_SERVICE }}'
+    state: 'started'
+  when: 'obtain_cert and TLS_LETSENCRYPT_TLS_SERVICE is defined'
+
+- name: Renewal command set
+  set_fact:
+    renewal_command: >
+      {{ certbot_executable }} renew
+      --pre-hook "service {{ TLS_LETSENCRYPT_TLS_SERVICE }} stop"
+      --post-hook "service {{ TLS_LETSENCRYPT_TLS_SERVICE }} start"
+      -n
+  when: 'TLS_LETSENCRYPT_TLS_SERVICE is defined'
+
+- name: Renewal command set
+  set_fact:
+    renewal_command: >
+      {{ certbot_executable }} renew
+      -n
+  when: 'TLS_LETSENCRYPT_TLS_SERVICE is not defined'
+
+- name: Renewal ran once
+  command: '{{ renewal_command }}'
+
+- name: Renewal automated via cron
+  cron:
+    hour: '*/12'
+    minute: '{{ 59 | random(seed=inventory_hostname) }}'
+    job: '{{ renewal_command }} --quiet'
+    name: 'certbot-renew'
+    stae: 'present'

--- a/tasks/deploy-provided.yml
+++ b/tasks/deploy-provided.yml
@@ -1,7 +1,7 @@
 ---
 
 - include: get-cert-cn.yml
-  when: 'TLS_DEST_BASENAME is undefined'
+  when: 'TLS_COMMON_NAME is undefined'
 
 - include: register-file-paths.yml
 
@@ -11,11 +11,11 @@
     src: '{{ item.src_path }}'
     dest: '{{ item.dest_path }}'
   with_items:
-    - src_path: '{{ TLS_PRIVKEY_SRC_FILE }}'
+    - src_path: '{{ TLS_BYO_PRIVKEY_SRC }}'
       dest_path: '{{ TLS_PRIVKEY_PATH }}'
-    - src_path: '{{ TLS_CERT_SRC_FILE }}'
+    - src_path: '{{ TLS_BYO_CERT_SRC }}'
       dest_path: '{{ TLS_CERT_PATH }}'
-    - src_path: '{{ TLS_CACHAIN_SRC_FILE }}'
+    - src_path: '{{ TLS_BYO_CACHAIN_SRC }}'
       dest_path: '{{ TLS_CACHAIN_PATH }}'
 
 # These series of tasks deserve an explanation.

--- a/tasks/deploy-provided.yml
+++ b/tasks/deploy-provided.yml
@@ -1,20 +1,20 @@
 ---
 
 - include: get-cert-cn.yml
-  when: TLS_DEST_BASENAME is undefined
+  when: 'TLS_DEST_BASENAME is undefined'
 
 - name: Certificate files copied to target
   tags: [certs-copied]
   copy:
-    src: "{{ item.src_path }}"
-    dest: "{{ item.dest_path }}"
+    src: '{{ item.src_path }}'
+    dest: '{{ item.dest_path }}'
   with_items:
-    - src_path: "{{ TLS_PRIVKEY_SRC_FILE }}"
-      dest_path: "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-    - src_path: "{{ TLS_CERT_SRC_FILE }}"
-      dest_path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
-    - src_path: "{{ TLS_CACHAIN_SRC_FILE }}"
-      dest_path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
+    - src_path: '{{ TLS_PRIVKEY_SRC_FILE }}'
+      dest_path: '{{ TLS_PRIVKEY_PATH }}'
+    - src_path: '{{ TLS_CERT_SRC_FILE }}'
+      dest_path: '{{ TLS_CERT_PATH }}'
+    - src_path: '{{ TLS_CACHAIN_SRC_FILE }}'
+      dest_path: '{{ TLS_CACHAIN_PATH }}'
 
 # These series of tasks deserve an explanation.
 #
@@ -25,25 +25,22 @@
 # output and if the dependencies are newer, then we recreate the output file.
 # a la make.
 
-- command: stat -c "%Y" "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
-  register: key_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
-  register: crt_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
-  register: cachain_timestamp
-  changed_when: False
-- command: stat -c "%Y"  "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
-  register: fullchain_timestamp
-  ignore_errors: yes # Intentionally fail, if the file doesn't exist
-  changed_when: False
+- command: 'stat -c "%Y" "{{ TLS_PRIVKEY_PATH }}"'
+  register: 'key_timestamp'
+  changed_when: false
+- command: 'stat -c "%Y"  "{{ TLS_CERT_PATH }}"'
+  register: 'crt_timestamp'
+  changed_when: false
+- command: 'stat -c "%Y"  "{{ TLS_CACHAIN_PATH }}"'
+  register: 'cachain_timestamp'
+  changed_when: false
+- command: 'stat -c "%Y"  "{{ TLS_FULLCHAIN_PATH }}"'
+  register: 'fullchain_timestamp'
+  ignore_errors: true # Intentionally fail, if the file doesn't exist
+  changed_when: false
 
 - name: Full certificate chain created
-  shell: >
-    cat {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
-    {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt >>
-    {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt
+  shell: 'cat {{ TLS_CERT_PATH }} {{ TLS_CACHAIN_PATH }} >> {{ TLS_FULLCHAIN_PATH }}'
   when: fullchain_timestamp|failed or (key_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
                                    or (crt_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
                                    or (cachain_timestamp.stdout|int() > fullchain_timestamp.stdout|int())

--- a/tasks/deploy-provided.yml
+++ b/tasks/deploy-provided.yml
@@ -18,31 +18,8 @@
     - src_path: '{{ TLS_BYO_CACHAIN_SRC }}'
       dest_path: '{{ TLS_CACHAIN_PATH }}'
 
-# These series of tasks deserve an explanation.
-#
-# In the task: 'Full certificate chain created', we must concatenate several
-# files. However we should only concatenate the files when any of the input
-# files have changed. At this time, ansible does not have a mechanism for
-# this. Here we manually check the timestamps of the dependencies and the
-# output and if the dependencies are newer, then we recreate the output file.
-# a la make.
-
-- command: 'stat -c "%Y" "{{ TLS_PRIVKEY_PATH }}"'
-  register: 'key_timestamp'
-  changed_when: false
-- command: 'stat -c "%Y"  "{{ TLS_CERT_PATH }}"'
-  register: 'crt_timestamp'
-  changed_when: false
-- command: 'stat -c "%Y"  "{{ TLS_CACHAIN_PATH }}"'
-  register: 'cachain_timestamp'
-  changed_when: false
-- command: 'stat -c "%Y"  "{{ TLS_FULLCHAIN_PATH }}"'
-  register: 'fullchain_timestamp'
-  ignore_errors: true # Intentionally fail, if the file doesn't exist
-  changed_when: false
-
 - name: Full certificate chain created
-  shell: 'cat {{ TLS_CERT_PATH }} {{ TLS_CACHAIN_PATH }} >> {{ TLS_FULLCHAIN_PATH }}'
+  shell: 'cat {{ TLS_CERT_PATH }} {{ TLS_CACHAIN_PATH }} > {{ TLS_FULLCHAIN_PATH }}'
   when: fullchain_timestamp|failed or (key_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
                                    or (crt_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
                                    or (cachain_timestamp.stdout|int() > fullchain_timestamp.stdout|int())

--- a/tasks/deploy-provided.yml
+++ b/tasks/deploy-provided.yml
@@ -3,6 +3,8 @@
 - include: get-cert-cn.yml
   when: 'TLS_DEST_BASENAME is undefined'
 
+- include: register-file-paths.yml
+
 - name: Certificate files copied to target
   tags: [certs-copied]
   copy:

--- a/tasks/deploy-provided.yml
+++ b/tasks/deploy-provided.yml
@@ -20,6 +20,3 @@
 
 - name: Full certificate chain created
   shell: 'cat {{ TLS_CERT_PATH }} {{ TLS_CACHAIN_PATH }} > {{ TLS_FULLCHAIN_PATH }}'
-  when: fullchain_timestamp|failed or (key_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
-                                   or (crt_timestamp.stdout|int()     > fullchain_timestamp.stdout|int())
-                                   or (cachain_timestamp.stdout|int() > fullchain_timestamp.stdout|int())

--- a/tasks/deploy-selfsigned.yml
+++ b/tasks/deploy-selfsigned.yml
@@ -14,6 +14,8 @@
     TLS_DEST_BASENAME: 'selfsigned'
   when: 'TLS_DEST_BASENAME is undefined'
 
+- include: register-file-paths.yml
+
 - name: Self-signed certificate and private key created
   tags: [selfsigned-cert-created]
   command: >

--- a/tasks/deploy-selfsigned.yml
+++ b/tasks/deploy-selfsigned.yml
@@ -1,18 +1,18 @@
 ---
-- name: Create a directory to store temporary files
+- name: Directory created to store temporary files
   file:
-    path: "{{ role_path }}/build"
-    state: directory
+    path: '{{ role_path }}/build'
+    state: 'directory'
 
-- name: Generate ssl configuration file
+- name: openssl configuration file created
   template:
-    src: "{{ role_path }}/templates/openssl-req.cnf.j2"
-    dest: "{{ role_path }}/build/openssl-req.cnf"
+    src: '{{ role_path }}/templates/openssl-req.cnf.j2'
+    dest: '{{ role_path }}/build/openssl-req.cnf'
 
 - name: TLS_DEST_BASENAME set to "selfsigned" if not already overridden
   set_fact:
-    TLS_DEST_BASENAME: selfsigned
-  when: TLS_DEST_BASENAME is undefined
+    TLS_DEST_BASENAME: 'selfsigned'
+  when: 'TLS_DEST_BASENAME is undefined'
 
 - name: Self-signed certificate and private key created
   tags: [selfsigned-cert-created]
@@ -23,23 +23,23 @@
     -x509
     -nodes
     -days 3650
-    -keyout {{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key
-    -out {{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt
+    -keyout {{ TLS_PRIVKEY_PATH }}
+    -out {{ TLS_CERT_PATH }}
   args:
-    creates: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
+    creates: '{{ TLS_CERT_PATH }}'
 
 - name: Empty CA chain file created
   tags: [selfsigned-empty-bundle-created]
   file:
-    path: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt"
-    state: touch
+    path: '{{ TLS_CACHAIN_PATH }}'
+    state: 'touch'
   # The following two lines work around https://github.com/ansible/ansible-modules-core/issues/170
-  register: touch_log
-  changed_when: touch_log.diff.before.state != "file"
+  register: 'touch_log'
+  changed_when: 'touch_log.diff.before.state != "file"'
 
 - name: Full certificate chain (same as bare self-signed certificate) created
   tags: [selfsigned-fullchain-created]
   copy:
-    src: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt"
-    dest: "{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt"
+    src: '{{ TLS_CERT_PATH }}'
+    dest: '{{ TLS_CACHAIN_PATH }}'
     remote_src: true

--- a/tasks/get-cert-cn.yml
+++ b/tasks/get-cert-cn.yml
@@ -5,11 +5,11 @@
 
 - name: Certificate copied to temporary location on target
   copy:
-    src: "{{ TLS_CERT_SRC_FILE }}"
+    src: "{{ TLS_BYO_CERT_SRC }}"
     dest: /tmp/ansible_tmp_cert
 
 - name: CN of provided certificate queried to determine TLS_DEST_BASENAME
-  # The following local_action may break if TLS_CERT_SRC_FILE is a relative path that is not resolveable from whichever working directory this is run
+  # The following local_action may break if TLS_BYO_CERT_SRC is a relative path that is not resolveable from whichever working directory this is run
   shell: openssl x509 -noout -subject -in /tmp/ansible_tmp_cert | sed -e 's/^subject.*CN=\([a-zA-Z0-9\.\-\*]*\).*$/\1/'
   register: CERT_CN
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     TLS_CERT_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt'
     TLS_CACHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt'
     TLS_FULLCHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt'
-  when: not TLS_LETSENCRYPT
+  when: TLS_LETSENCRYPT is undefined
 
 - include: deploy-provided.yml
   when: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,16 +22,16 @@
 - include: deploy-provided.yml
   when: >
       TLS_LETSENCRYPT is not defined and
-      TLS_PRIVKEY_SRC_FILE is defined and
-      TLS_CERT_SRC_FILE is defined and
-      TLS_CACHAIN_SRC_FILE is defined
+      TLS_BYO_PRIVKEY_SRC is defined and
+      TLS_BYO_CERT_SRC is defined and
+      TLS_BYO_CACHAIN_SRC is defined
 
 - include: deploy-selfsigned.yml
   when: >
       TLS_LETSENCRYPT is not defined and
-      TLS_PRIVKEY_SRC_FILE is not defined and
-      TLS_CERT_SRC_FILE is not defined and
-      TLS_CACHAIN_SRC_FILE is not defined
+      TLS_BYO_PRIVKEY_SRC is not defined and
+      TLS_BYO_CERT_SRC is not defined and
+      TLS_BYO_CACHAIN_SRC is not defined
 
 - name: Restricted file permissions set on private key
   when: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,15 +21,14 @@
 
 - include: deploy-provided.yml
   when: >
-      not TLS_LETSENCRYPT and
-      not TLS_CREATE_SELFSIGNED and
+      TLS_LETSENCRYPT is not defined and
       TLS_PRIVKEY_SRC_FILE is defined and
       TLS_CERT_SRC_FILE is defined and
       TLS_CACHAIN_SRC_FILE is defined
 
 - include: deploy-selfsigned.yml
   when: >
-      not TLS_LETSENCRYPT and
+      TLS_LETSENCRYPT is not defined and
       TLS_PRIVKEY_SRC_FILE is not defined and
       TLS_CERT_SRC_FILE is not defined and
       TLS_CACHAIN_SRC_FILE is not defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,14 +19,6 @@
     - '{{ TLS_CERT_DEST_DIR }}'
   when: TLS_LETSENCRYPT is not defined
 
-- name: File paths registered
-  set_fact:
-    TLS_PRIVKEY_PATH: '{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key'
-    TLS_CERT_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt'
-    TLS_CACHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt'
-    TLS_FULLCHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt'
-  when: TLS_LETSENCRYPT is not defined
-
 - include: deploy-provided.yml
   when: >
       not TLS_LETSENCRYPT and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     TLS_CERT_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt'
     TLS_CACHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt'
     TLS_FULLCHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt'
-  when: TLS_LETSENCRYPT is undefined
+  when: TLS_LETSENCRYPT is not defined
 
 - include: deploy-provided.yml
   when: >
@@ -39,9 +39,9 @@
 - include: deploy-selfsigned.yml
   when: >
       not TLS_LETSENCRYPT and
-      TLS_PRIVKEY_SRC_FILE is undefined and
-      TLS_CERT_SRC_FILE is undefined and
-      TLS_CACHAIN_SRC_FILE is undefined
+      TLS_PRIVKEY_SRC_FILE is not defined and
+      TLS_CERT_SRC_FILE is not defined and
+      TLS_CACHAIN_SRC_FILE is not defined
 
 - name: Restricted file permissions set on private key
   when: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,7 @@
     - '{{ ansible_distribution }}.yml'
 
 - include: 'deploy-letsencrypt.yml'
-  when: >
-      TLS_LETSENCRYPT
+  when: TLS_LETSENCRYPT is defined
 
 - name: Ensure distro default cert paths exist
   tags: [ensure-distro-cert-paths]
@@ -18,7 +17,7 @@
   with_items:
     - '{{ TLS_PRIVKEY_DEST_DIR }}'
     - '{{ TLS_CERT_DEST_DIR }}'
-  when: not TLS_LETSENCRYPT
+  when: TLS_LETSENCRYPT is not defined
 
 - name: File paths registered
   set_fact:
@@ -45,7 +44,7 @@
 
 - name: Restricted file permissions set on private key
   when: >
-      not TLS_LETSENCRYPT and
+      TLS_LETSENCRYPT is not defined and
       ansible_distribution == "CentOS"
   file:
     path: '{{ TLS_PRIVKEY_PATH }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,37 @@
 ---
 
 - name: Distro-specific variables gathered
-  include_vars: "{{ item }}"
+  include_vars: '{{ item }}'
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
-    - "{{ ansible_distribution }}.yml"
+    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml'
+    - '{{ ansible_distribution }}.yml'
+
+- include: 'deploy-letsencrypt.yml'
+  when: >
+      TLS_LETSENCRYPT and
+      not TLS_CREATE_SELFSIGNED
 
 - name: Ensure distro default cert paths exist
   tags: [ensure-distro-cert-paths]
   file:
-    path: "{{ item }}"
+    path: '{{ item }}'
     state: directory
   with_items:
-    - "{{ TLS_PRIVKEY_DEST_DIR }}"
-    - "{{ TLS_CERT_DEST_DIR }}"
+    - '{{ TLS_PRIVKEY_DEST_DIR }}'
+    - '{{ TLS_CERT_DEST_DIR }}'
+  when: not TLS_LETSENCRYPT
+
+- name: File paths registered
+  set_fact:
+    TLS_PRIVKEY_PATH: '{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key'
+    TLS_CERT_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt'
+    TLS_CACHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt'
+    TLS_FULLCHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt'
+  when: not TLS_LETSENCRYPT
 
 - include: deploy-provided.yml
   when: >
+      not TLS_LETSENCRYPT and
       not TLS_CREATE_SELFSIGNED and
       TLS_PRIVKEY_SRC_FILE is defined and
       TLS_CERT_SRC_FILE is defined and
@@ -24,14 +39,17 @@
 
 - include: deploy-selfsigned.yml
   when: >
+      not TLS_LETSENCRYPT and
       TLS_CREATE_SELFSIGNED or
       TLS_PRIVKEY_SRC_FILE is undefined or
       TLS_CERT_SRC_FILE is undefined or
       TLS_CACHAIN_SRC_FILE is undefined
 
 - name: Restricted file permissions set on private key
-  when: ansible_distribution == "CentOS"
+  when: >
+      not TLS_LETSENCRYPT and
+      ansible_distribution == "CentOS"
   file:
-    path: "{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key"
+    path: '{{ TLS_PRIVKEY_PATH }}'
     owner: root
     mode: 0600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,8 +8,7 @@
 
 - include: 'deploy-letsencrypt.yml'
   when: >
-      TLS_LETSENCRYPT and
-      not TLS_CREATE_SELFSIGNED
+      TLS_LETSENCRYPT
 
 - name: Ensure distro default cert paths exist
   tags: [ensure-distro-cert-paths]
@@ -40,9 +39,8 @@
 - include: deploy-selfsigned.yml
   when: >
       not TLS_LETSENCRYPT and
-      TLS_CREATE_SELFSIGNED or
-      TLS_PRIVKEY_SRC_FILE is undefined or
-      TLS_CERT_SRC_FILE is undefined or
+      TLS_PRIVKEY_SRC_FILE is undefined and
+      TLS_CERT_SRC_FILE is undefined and
       TLS_CACHAIN_SRC_FILE is undefined
 
 - name: Restricted file permissions set on private key

--- a/tasks/register-file-paths.yml
+++ b/tasks/register-file-paths.yml
@@ -1,0 +1,6 @@
+- name: File paths registered
+  set_fact:
+    TLS_PRIVKEY_PATH: '{{ TLS_PRIVKEY_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.key'
+    TLS_CERT_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.crt'
+    TLS_CACHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.cachain.crt'
+    TLS_FULLCHAIN_PATH: '{{ TLS_CERT_DEST_DIR }}/{{ TLS_DEST_BASENAME }}.fullchain.crt'

--- a/templates/openssl-req.cnf.j2
+++ b/templates/openssl-req.cnf.j2
@@ -12,7 +12,7 @@ ST           = 'Arizona')
 L            = 'Tucson')
 O            = 'Organization Name')
 OU           = 'Organization Division')
-CN           = {{ TLS_SUBJECT_ALTERNATE_NAME | default(ansible_fqdn) }}
+CN           = {{ TLS_COMMON_NAME }}
 emailAddress = 'test@example.com'
 
 [ server_req_extensions ]
@@ -24,4 +24,4 @@ subjectAltName         = @alternate_names
 nsComment              = "OpenSSL Generated Certificate"
 
 [ alternate_names ]
-DNS.1 = {{ TLS_SUBJECT_ALTERNATE_NAME | default(ansible_fqdn) }}
+DNS.1 = {{ TLS_COMMON_NAME }}


### PR DESCRIPTION
- Added support for obtaining a TLS certificate from Let's Encrypt and automating certificate renewal via cron
- Converted double-quoted YAML strings to single-quoted throughout role
- Overhauled README
- Explicitly registering variables for destination file paths on target, for use in downstream automations
- Dropped support for CentOS 5 and Ubuntu 12.04
- Added Connor to authors list (because he wrote a lot of this role)