### PR TITLE
Absorb tls-cert role from clank

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,14 @@ services:
   - docker
 
 env:
-# For some reason Travis tests fail like this for CentOS 7 Docker container, even though it works fine on a real VM
-# TASK [role_under_test : Self-signed certificate and private key created] *******
-# fatal: [localhost]: FAILED! => {"changed": false, "cmd": "openssl req -new -x509 -nodes -extensions v3_ca -days 3650 -subj / -keyout /etc/pki/tls/private/selfsigned.key -out /etc/pki/tls/certs/selfsigned.crt", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}
-#   - distribution: centos
-#     version: 7
+  - distribution: centos
+    version: 7
   - distribution: centos
     version: 6
-# No supported/sane way to run Ansible inside a CentOS 5 Docker container;
-#   - distribution: centos
-#     version: 5
   - distribution: ubuntu
     version: 16.04
   - distribution: ubuntu
     version: 14.04
-#  - distribution: ubuntu
-#    version: 12.04
 
 before_install:
   - 'sudo docker run -it --name=test_dummy --privileged --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:rw cyverse/ansible-test:latest-${distribution}-${version} bash'
@@ -35,17 +27,7 @@ script:
   # 2. Run playbook to execute role
   - "sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --connection=local"
 
-  # 3. HERE, WRITE SOME TESTS to verify that your role has produced the desired
-  # effect on the target system. Your tests should be bash commands that
-  # complete with an exit status of 0 for a pass, and non-zero for a failure.
-  #
-  # This example tests whether 'hello' exists in /tmp/hello.txt.
-  # - >
-  #   sudo docker exec test_dummy bash -c cat /tmp/hello.txt | grep -q 'hello'
-  #   && (echo 'Test for role result: pass' && exit 0)
-  #   || (echo 'Test for role result: fail' && exit 1)
-
-  # 4. Idempotence test (run playbook again to confirm nothing changes)
+  # 3. Idempotence test (run playbook again to confirm nothing changes)
   - >
     sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --connection=local
     | grep -q 'changed=0.*failed=0'

--- a/tasks/deploy-provided.yml
+++ b/tasks/deploy-provided.yml
@@ -1,9 +1,9 @@
 ---
 
-- include: get-cert-cn.yml
+- import_tasks: get-cert-cn.yml
   when: 'TLS_COMMON_NAME is undefined'
 
-- include: register-file-paths.yml
+- import_tasks: register-file-paths.yml
 
 - name: Certificate files copied to target
   tags: [certs-copied]

--- a/tasks/deploy-selfsigned.yml
+++ b/tasks/deploy-selfsigned.yml
@@ -14,7 +14,7 @@
     TLS_DEST_BASENAME: 'selfsigned'
   when: 'TLS_DEST_BASENAME is undefined'
 
-- include: register-file-paths.yml
+- import_tasks: register-file-paths.yml
 
 - name: Self-signed certificate and private key created
   tags: [selfsigned-cert-created]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     - '{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml'
     - '{{ ansible_distribution }}.yml'
 
-- include: 'deploy-letsencrypt.yml'
+- import_tasks: 'deploy-letsencrypt.yml'
   when: TLS_LETSENCRYPT_ENABLE is defined
 
 - name: Ensure distro default cert paths exist
@@ -19,14 +19,14 @@
     - '{{ TLS_CERT_DEST_DIR }}'
   when: TLS_LETSENCRYPT_ENABLE is not defined
 
-- include: deploy-provided.yml
+- import_tasks: deploy-provided.yml
   when: >
       TLS_LETSENCRYPT_ENABLE is not defined and
       TLS_BYO_PRIVKEY_SRC is defined and
       TLS_BYO_CERT_SRC is defined and
       TLS_BYO_CACHAIN_SRC is defined
 
-- include: deploy-selfsigned.yml
+- import_tasks: deploy-selfsigned.yml
   when: >
       TLS_LETSENCRYPT_ENABLE is not defined and
       TLS_BYO_PRIVKEY_SRC is not defined and


### PR DESCRIPTION
The only changes to absorb were an upgrade to ansible to 2.4.2, which deprecates include for import_playbook and import_tasks.

A follow up PR to clank will remove the tls-cert role.